### PR TITLE
ECO-1042 StoreOrderRequestMapper is mapping idCustomer instead of customerReference

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,8 +1,7 @@
 build:
     dependencies:
         before:
-            - composer config repositories.spryker git git@github.com:spryker/spryker.git
-            - composer config repositories.spryker-private composer https://code.spryker.com/repo/private
+            - composer config repositories.spryker composer https://code.spryker.com/repo/private
     environment:
         php:
             version: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
 services:
   - postgresql
   - redis
+  - rabbitmq
 
 addons:
   postgresql: 9.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: required
 matrix:
   fast_finish: true
   include:
-     - php: "7.1"
+     - php: 7.1
 
 services:
   - postgresql
@@ -54,7 +54,6 @@ install:
   - chmod -R 777 data/
   - config/Shared/ci/travis/install_elasticsearch.sh
 
-  - mv config/Zed/propel.ci.yml config/Zed/propel.yml
   - cat config/Shared/ci/travis/postgresql_ci.config >> config/Shared/ci/travis/config_ci.php
   - cp config/Shared/ci/travis/config_ci.php config/Shared/config_default-devtest_DE.php
   - cp config/Shared/ci/travis/params_test_env.sh deploy/setup/params_test_env.sh

--- a/build/travis.sh
+++ b/build/travis.sh
@@ -42,7 +42,7 @@ function runTests {
 
 function checkArchRules {
     echo "Running Architecture sniffer..."
-    errors=`vendor/bin/phpmd "vendor/spryker-eco/$MODULE_NAME/src" text vendor/spryker/architecture-sniffer/src/ruleset.xml --minimumpriority=2`
+    errors=`vendor/bin/phpmd "vendor/spryker-eco/$MODULE_NAME/src" text vendor/spryker/architecture-sniffer/src/ruleset.xml --minimumpriority=2 | grep -v __construct`
 
     if [[ "$errors" = "" ]]; then
         buildMessage="$buildMessage\n${GREEN}Architecture sniffer reports no errors"
@@ -61,10 +61,10 @@ function checkCodeSniffRules {
     fi
 
     echo "Running code sniffer..."
-    errors=`vendor/bin/console code:sniff "vendor/spryker-eco/$MODULE_NAME/src"`
-    errorsCount=$?
+    errors=`vendor/bin/console code:sniff:style "vendor/spryker-eco/$MODULE_NAME/src"`
+    errorsPresent=$?
 
-    if [[ "$errorsCount" = "0" ]]; then
+    if [[ "$errorsPresent" = "0" ]]; then
         buildMessage="$buildMessage\n${GREEN}Code sniffer reports no errors"
     else
         echo -e "$errors"
@@ -73,8 +73,6 @@ function checkCodeSniffRules {
 }
 
 function checkPHPStan {
-    echo "Installing PHPStan..."
-    composer require --dev phpstan/phpstan
     echo "Updating code-completition..."
     vendor/bin/console dev:ide:generate-auto-completion
     echo "Running PHPStan..."

--- a/src/SprykerEco/Client/ArvatoRss/ArvatoRssClient.php
+++ b/src/SprykerEco/Client/ArvatoRss/ArvatoRssClient.php
@@ -16,6 +16,10 @@ use Spryker\Client\Kernel\AbstractClient;
 class ArvatoRssClient extends AbstractClient implements ArvatoRssClientInterface
 {
     /**
+     * {@inheritdoc}
+     *
+     * @api
+     *
      * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
      *
      * @return \Generated\Shared\Transfer\QuoteTransfer

--- a/src/SprykerEco/Service/ArvatoRss/Iso3166ConverterService.php
+++ b/src/SprykerEco/Service/ArvatoRss/Iso3166ConverterService.php
@@ -16,6 +16,10 @@ class Iso3166ConverterService extends AbstractService implements Iso3166Converte
     const ISO3166_KEY = 'numeric';
 
     /**
+     * {@inheritdoc}
+     *
+     * @api
+     *
      * @param string $iso2CountryCode
      *
      * @return string|null
@@ -31,6 +35,10 @@ class Iso3166ConverterService extends AbstractService implements Iso3166Converte
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * @api
+     *
      * @param string $iso3166CountryCode
      *
      * @return string|null

--- a/src/SprykerEco/Zed/ArvatoRss/Business/Api/Mapper/StoreOrderRequestMapper.php
+++ b/src/SprykerEco/Zed/ArvatoRss/Business/Api/Mapper/StoreOrderRequestMapper.php
@@ -84,7 +84,7 @@ class StoreOrderRequestMapper implements StoreOrderRequestMapperInterface
             )
         );
         if ($orderTransfer->getCustomer()) {
-            $order->setDebitorNumber($orderTransfer->getCustomer()->getIdCustomer());
+            $order->setDebitorNumber($orderTransfer->getCustomer()->getCustomerReference());
         }
 
         return $order;

--- a/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Mapper/StoreOrderRequestMapperTest.php
+++ b/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Mapper/StoreOrderRequestMapperTest.php
@@ -47,6 +47,10 @@ class StoreOrderRequestMapperTest extends AbstractBusinessTest
             $result->getOrder()->getPaymentType(),
             ArvatoRssApiConfig::INVOICE
         );
+        $this->assertEquals(
+            $result->getOrder()->getDebitorNumber(),
+            $this->order->getCustomer()->getCustomerReference()
+        );
     }
 
     /**


### PR DESCRIPTION
- Developer(s): @aleksey-kotsuba

- Peer Reviewer:

- Ticket: https://spryker.atlassian.net/browse/ECO-1042

- Project PR: https://github.com/spryker-eco/arvato-rss

- Academy PR:


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department
- [ ] All new or heavily changed classes get an "A" rating (Scrutinizer), except Facades, Factories, QueryContainers and Tests

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ArvatoRss             | patch (new)           |                       |

#### Release Notes



-----------------------------------------

#### Module ArvatoRss

_**Patch:** Backwards-compatible bug fix_

Def of done (by responsible developer):
- [ ] All changes are backward-compatible. Outdated code is marked as deprecated.
- [ ] The change is isolated and not mixed with any cleanups or other changes.
- [ ] New code fits to the architecture rules.
- [ ] All new or changed business logic is covered by functional tests (in Zed business layer).

##### Change log

### Bugfixes
DebitorNumber field in ArvatoRssOrderTransfer has been mapped to customerReference instead of idCustomer.

