### PR TITLE
ECO-1039: Error in Arvato RSS Response

### DIFF
--- a/src/SprykerEco/Zed/ArvatoRss/Business/Api/Converter/RiskCheckResponseConverter.php
+++ b/src/SprykerEco/Zed/ArvatoRss/Business/Api/Converter/RiskCheckResponseConverter.php
@@ -29,24 +29,49 @@ class RiskCheckResponseConverter implements RiskCheckResponseConverterInterface
         $responseTransfer->setCommunicationToken($response->Decision->CommunicationToken);
 
         if (isset($response->Details)) {
-            if (isset($response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse)) {
-                $responseTransfer->setBillingAddressValidation(
-                    $this->convertAddressValidationResponse(
-                        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse
-                    )
-                );
-            }
-
-            if (isset($response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse)) {
-                $responseTransfer->setDeliveryAddressValidation(
-                    $this->convertAddressValidationResponse(
-                        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse
-                    )
-                );
-            }
+            $this->processBillingAddressResponse($responseTransfer, $response->Details->BillingCustomerResult);
+            $this->processDeliveryAddressResponse($responseTransfer, $response->Details->DeliveryCustomerResult);
         }
 
         return $responseTransfer;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ArvatoRssRiskCheckResponseTransfer $responseTransfer
+     * @param \stdClass $response
+     *
+     * @return void
+     */
+    protected function processBillingAddressResponse(
+        ArvatoRssRiskCheckResponseTransfer $responseTransfer,
+        stdClass $response
+    ) {
+        if (isset($response->ServiceResults->AddressValidationResponse)) {
+            $responseTransfer->setBillingAddressValidation(
+                $this->convertAddressValidationResponse(
+                    $response->ServiceResults->AddressValidationResponse
+                )
+            );
+        }
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ArvatoRssRiskCheckResponseTransfer $responseTransfer
+     * @param \stdClass $response
+     *
+     * @return void
+     */
+    protected function processDeliveryAddressResponse(
+        ArvatoRssRiskCheckResponseTransfer $responseTransfer,
+        stdClass $response
+    ) {
+        if (isset($response->ServiceResults->AddressValidationResponse)) {
+            $responseTransfer->setDeliveryAddressValidation(
+                $this->convertAddressValidationResponse(
+                    $response->ServiceResults->AddressValidationResponse
+                )
+            );
+        }
     }
 
     /**

--- a/src/SprykerEco/Zed/ArvatoRss/Business/Api/Converter/RiskCheckResponseConverter.php
+++ b/src/SprykerEco/Zed/ArvatoRss/Business/Api/Converter/RiskCheckResponseConverter.php
@@ -29,17 +29,21 @@ class RiskCheckResponseConverter implements RiskCheckResponseConverterInterface
         $responseTransfer->setCommunicationToken($response->Decision->CommunicationToken);
 
         if (isset($response->Details)) {
-            $responseTransfer->setBillingAddressValidation(
-                $this->convertAddressValidationResponse(
-                    $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse
-                )
-            );
+            if (isset($response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse)) {
+                $responseTransfer->setBillingAddressValidation(
+                    $this->convertAddressValidationResponse(
+                        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse
+                    )
+                );
+            }
 
-            $responseTransfer->setDeliveryAddressValidation(
-                $this->convertAddressValidationResponse(
-                    $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse
-                )
-            );
+            if (isset($response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse)) {
+                $responseTransfer->setDeliveryAddressValidation(
+                    $this->convertAddressValidationResponse(
+                        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse
+                    )
+                );
+            }
         }
 
         return $responseTransfer;

--- a/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Converter/RiskCheckResponseConverterTest.php
+++ b/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Converter/RiskCheckResponseConverterTest.php
@@ -39,16 +39,21 @@ class RiskCheckResponseConverterTest extends Test
         $simpleResponse = self::createResponse();
         $simpleExpected = self::createExpectedResult($simpleResponse);
 
-        $responseWithAddresses = $simpleResponse;
-        $responseWithAddresses->Details = new stdClass();
-        $responseWithAddresses->Details->BillingCustomerResult = self::createAddressResponse();
-        $responseWithAddresses->Details->DeliveryCustomerResult = self::createAddressResponse();
-        $expectedWithAddress = $simpleExpected
+        $responseWithoutAddress = $simpleResponse;
+        $responseWithoutAddress->Details = new stdClass();
+        $responseWithoutAddress->Details->BillingCustomerResult = self::createAddressResponse();
+        $responseWithoutAddress->Details->DeliveryCustomerResult = new stdClass();
+        $responseWithoutAddress->Details->DeliveryCustomerResult->ServiceResults = new stdClass();
+        $expectedWithoutAddress = $simpleExpected
             ->setBillingAddressValidation(
                 self::createAddressValidationTransfer(
-                    $responseWithAddresses->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse
+                    $responseWithoutAddress->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse
                 )
-            )
+            );
+
+        $responseWithAddresses = $responseWithoutAddress;
+        $responseWithAddresses->Details->DeliveryCustomerResult = self::createAddressResponse();
+        $expectedWithAddress = $expectedWithoutAddress
             ->setDeliveryAddressValidation(
                 self::createAddressValidationTransfer(
                     $responseWithAddresses->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse
@@ -74,6 +79,7 @@ class RiskCheckResponseConverterTest extends Test
             'simple response' => [$simpleResponse, $simpleExpected],
             'response with addresses' => [$responseWithAddresses, $expectedWithAddress],
             'response with additional address field' => [$responseWithAdditionalAddress, $expectedWithAdditionalField],
+            'response without address' => [$responseWithoutAddress, $expectedWithoutAddress]
         ];
     }
 


### PR DESCRIPTION
- Developer(s): @aleksey-kotsuba

- Peer Reviewer:

- Ticket: https://spryker.atlassian.net/browse/ECO-1039

- Project PR: https://github.com/spryker-eco/arvato-rss

- Academy PR:


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department
- [ ] All new or heavily changed classes get an "A" rating (Scrutinizer), except Facades, Factories, QueryContainers and Tests

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ArvatoRss             | patch (new)           |                       |

#### Release Notes



-----------------------------------------

#### Module ArvatoRss

_**Patch:** Backwards-compatible bug fix_

Def of done (by responsible developer):
- [ ] All changes are backward-compatible. Outdated code is marked as deprecated.
- [ ] The change is isolated and not mixed with any cleanups or other changes.
- [ ] New code fits to the architecture rules.
- [ ] All new or changed business logic is covered by functional tests (in Zed business layer).

##### Change log

### Bugfixes
Check for presence AddressValidationResponse field in api response has beed added.

