### PR TITLE
ECO-1044: Only send delivery address, when its different from billing address

### DIFF
--- a/src/SprykerEco/Zed/ArvatoRss/Business/Api/Converter/RiskCheckRequestConverter.php
+++ b/src/SprykerEco/Zed/ArvatoRss/Business/Api/Converter/RiskCheckRequestConverter.php
@@ -20,11 +20,13 @@ class RiskCheckRequestConverter implements RiskCheckRequestConverterInterface
      */
     public function convert(ArvatoRssRiskCheckRequestTransfer $arvatoRssRiskCheckRequestTransfer)
     {
-        $billingCustomer = $this->convertBillingCustomer($arvatoRssRiskCheckRequestTransfer);
-        $deliveryCustomer = $this->convertDeliveryCustomer($arvatoRssRiskCheckRequestTransfer);
-        $order = $this->convertOrder($arvatoRssRiskCheckRequestTransfer);
+        $result = $this->convertBillingCustomer($arvatoRssRiskCheckRequestTransfer);
+        if ($arvatoRssRiskCheckRequestTransfer->getDeliveryCustomer()) {
+            $result += $this->convertDeliveryCustomer($arvatoRssRiskCheckRequestTransfer);
+        }
+        $result += $this->convertOrder($arvatoRssRiskCheckRequestTransfer);
 
-        return $billingCustomer + $deliveryCustomer + $order;
+        return $result;
     }
 
     /**

--- a/src/SprykerEco/Zed/ArvatoRss/Business/Api/Converter/RiskCheckResponseConverter.php
+++ b/src/SprykerEco/Zed/ArvatoRss/Business/Api/Converter/RiskCheckResponseConverter.php
@@ -30,7 +30,9 @@ class RiskCheckResponseConverter implements RiskCheckResponseConverterInterface
 
         if (isset($response->Details)) {
             $this->processBillingAddressResponse($responseTransfer, $response->Details->BillingCustomerResult);
-            $this->processDeliveryAddressResponse($responseTransfer, $response->Details->DeliveryCustomerResult);
+            if (isset($response->Details->DeliveryCustomerResult)) {
+                $this->processDeliveryAddressResponse($responseTransfer, $response->Details->DeliveryCustomerResult);
+            }
         }
 
         return $responseTransfer;

--- a/src/SprykerEco/Zed/ArvatoRss/Business/Api/Mapper/RiskCheckRequestMapper.php
+++ b/src/SprykerEco/Zed/ArvatoRss/Business/Api/Mapper/RiskCheckRequestMapper.php
@@ -70,17 +70,22 @@ class RiskCheckRequestMapper implements RiskCheckRequestMapperInterface
         $billingCustomerTransfer = $this->billingCustomerMapper->map(
             $this->createBillingCustomerMapperTransfer($quoteTransfer)
         );
-        $deliveryCustomerTransfer = $this->deliveryCustomerMapper->map(
-            $this->createDeliveryCustomerMapperTransfer($quoteTransfer)
-        );
+
         $orderTransfer = $this->orderMapper->map(
             $this->createOrderMaperTransfer($quoteTransfer)
         );
 
         $requestTransfer->setIdentification($identificationRequestTransfer);
         $requestTransfer->setBillingCustomer($billingCustomerTransfer);
-        $requestTransfer->setDeliveryCustomer($deliveryCustomerTransfer);
         $requestTransfer->setOrder($orderTransfer);
+
+        if (!$quoteTransfer->getBillingSameAsShipping()) {
+            $deliveryCustomerTransfer = $this->deliveryCustomerMapper->map(
+                $this->createDeliveryCustomerMapperTransfer($quoteTransfer)
+            );
+
+            $requestTransfer->setDeliveryCustomer($deliveryCustomerTransfer);
+        }
 
         return $requestTransfer;
     }

--- a/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Converter/RiskCheckRequestConverterTest.php
+++ b/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Converter/RiskCheckRequestConverterTest.php
@@ -148,9 +148,15 @@ class RiskCheckRequestConverterTest extends Test
             )
             ->withOrder()
             ->build();
+        $requestWithoutAddress = (new ArvatoRssRiskCheckRequestBuilder())
+            ->withIdentification()
+            ->withBillingCustomer((new ArvatoRssBillingCustomerBuilder())->withAddress())
+            ->withOrder()
+            ->build();
         return [
             'with additional address' => [$requestWithAdditionalAddress],
-            'without additional address' => [$requestWithoutAdditionalAddress]
+            'without additional address' => [$requestWithoutAdditionalAddress],
+            'without delivery address' => [$requestWithoutAddress],
         ];
     }
 }

--- a/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Converter/RiskCheckResponseConverterTest.php
+++ b/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Converter/RiskCheckResponseConverterTest.php
@@ -29,8 +29,6 @@ class RiskCheckResponseConverterTest extends Test
         $actual = $converter->convert($response);
 
         $this->assertEquals($expected, $actual);
-
-        $this->testDeliveryPresents($converter);
     }
 
     /**
@@ -148,60 +146,5 @@ class RiskCheckResponseConverterTest extends Test
             ->setZipCode($response->ZipCode)
             ->setCity($response->City)
             ->setCountry($response->Country);
-    }
-
-    /**
-     * @param RiskCheckResponseConverter $converter
-     */
-    protected function testDeliveryPresents(RiskCheckResponseConverter $converter)
-    {
-        $result = $converter->convert($this->createResponseWithDelivery());
-
-        $this->assertInstanceOf(
-            ArvatoRssAddressValidationResponseTransfer::class,
-            $result->getDeliveryAddressValidation()
-        );
-
-        $result = $converter->convert($this->createResponseWithBilling());
-        $this->assertEmpty($result->getDeliveryAddressValidation());
-    }
-
-    /**
-     * @return stdClass
-     */
-    protected function createResponseWithDelivery()
-    {
-        $response = $this->createResponseWithBilling();
-        $response->Details->DeliveryCustomerResult = new stdClass();
-        $response->Details->DeliveryCustomerResult->ServiceResults = new stdClass();
-        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse = new stdClass();
-        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse->ReturnCode = 'ReturnCode';
-        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse->Street = 'Street';
-        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse->StreetNumber = 'StreetNumber';
-        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse->ZipCode = 'ZipCode';
-        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse->City = 'City';
-        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse->Country = 'Country';
-
-        return $response;
-    }
-
-    /**
-     * @return stdClass
-     */
-    protected function createResponseWithBilling()
-    {
-        $response = $this->createResponse();
-        $response->Details = new stdClass();
-        $response->Details->BillingCustomerResult = new stdClass();
-        $response->Details->BillingCustomerResult->ServiceResults = new stdClass();
-        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse = new stdClass();
-        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse->ReturnCode = 'ReturnCode';
-        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse->Street = 'Street';
-        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse->StreetNumber = 'StreetNumber';
-        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse->ZipCode = 'ZipCode';
-        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse->City = 'City';
-        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse->Country = 'Country';
-
-        return $response;
     }
 }

--- a/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Converter/RiskCheckResponseConverterTest.php
+++ b/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Converter/RiskCheckResponseConverterTest.php
@@ -29,6 +29,8 @@ class RiskCheckResponseConverterTest extends Test
         $actual = $converter->convert($response);
 
         $this->assertEquals($expected, $actual);
+
+        $this->testDeliveryPresents($converter);
     }
 
     /**
@@ -146,5 +148,60 @@ class RiskCheckResponseConverterTest extends Test
             ->setZipCode($response->ZipCode)
             ->setCity($response->City)
             ->setCountry($response->Country);
+    }
+
+    /**
+     * @param RiskCheckResponseConverter $converter
+     */
+    protected function testDeliveryPresents(RiskCheckResponseConverter $converter)
+    {
+        $result = $converter->convert($this->createResponseWithDelivery());
+
+        $this->assertInstanceOf(
+            ArvatoRssAddressValidationResponseTransfer::class,
+            $result->getDeliveryAddressValidation()
+        );
+
+        $result = $converter->convert($this->createResponseWithBilling());
+        $this->assertEmpty($result->getDeliveryAddressValidation());
+    }
+
+    /**
+     * @return stdClass
+     */
+    protected function createResponseWithDelivery()
+    {
+        $response = $this->createResponseWithBilling();
+        $response->Details->DeliveryCustomerResult = new stdClass();
+        $response->Details->DeliveryCustomerResult->ServiceResults = new stdClass();
+        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse = new stdClass();
+        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse->ReturnCode = 'ReturnCode';
+        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse->Street = 'Street';
+        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse->StreetNumber = 'StreetNumber';
+        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse->ZipCode = 'ZipCode';
+        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse->City = 'City';
+        $response->Details->DeliveryCustomerResult->ServiceResults->AddressValidationResponse->Country = 'Country';
+
+        return $response;
+    }
+
+    /**
+     * @return stdClass
+     */
+    protected function createResponseWithBilling()
+    {
+        $response = $this->createResponse();
+        $response->Details = new stdClass();
+        $response->Details->BillingCustomerResult = new stdClass();
+        $response->Details->BillingCustomerResult->ServiceResults = new stdClass();
+        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse = new stdClass();
+        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse->ReturnCode = 'ReturnCode';
+        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse->Street = 'Street';
+        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse->StreetNumber = 'StreetNumber';
+        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse->ZipCode = 'ZipCode';
+        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse->City = 'City';
+        $response->Details->BillingCustomerResult->ServiceResults->AddressValidationResponse->Country = 'Country';
+
+        return $response;
     }
 }

--- a/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Mapper/RiskCheckRequestMapperTest.php
+++ b/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Mapper/RiskCheckRequestMapperTest.php
@@ -54,9 +54,8 @@ class RiskCheckRequestMapperTest extends AbstractBusinessTest
         $this->assertInstanceOf(ArvatoRssRiskCheckRequestTransfer::class, $result);
         $this->assertInstanceOf(ArvatoRssIdentificationRequestTransfer::class, $result->getIdentification());
         $this->assertInstanceOf(ArvatoRssBillingCustomerTransfer::class, $result->getBillingCustomer());
-        $this->assertInstanceOf(ArvatoRssDeliveryCustomerTransfer::class, $result->getDeliveryCustomer());
         $this->assertInstanceOf(ArvatoRssOrderTransfer::class, $result->getOrder());
-        $this->assertEquals($quote->getBillingSameAsShipping(), (bool) $result->getDeliveryCustomer());
+        $this->assertNotEquals($quote->getBillingSameAsShipping(), (bool) $result->getDeliveryCustomer());
     }
 
     /**

--- a/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Mapper/RiskCheckRequestMapperTest.php
+++ b/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Mapper/RiskCheckRequestMapperTest.php
@@ -34,6 +34,8 @@ class RiskCheckRequestMapperTest extends AbstractBusinessTest
         );
         $result = $mapper->mapQuoteToRequestTranfer($this->quote);
         $this->testResult($result);
+
+        $this->testBillingSameAsShipping($mapper);
     }
 
     /**
@@ -108,5 +110,19 @@ class RiskCheckRequestMapperTest extends AbstractBusinessTest
             ->willReturn(new ArvatoRssOrderTransfer());
 
         return $moneyFacadeMock;
+    }
+
+    /**
+     * @param RiskCheckRequestMapper $mapper
+     */
+    protected function testBillingSameAsShipping(RiskCheckRequestMapper $mapper)
+    {
+        $this->quote->setBillingSameAsShipping(true);
+        $result = $mapper->mapQuoteToRequestTranfer($this->quote);
+        $this->assertEmpty($result->getDeliveryCustomer());
+
+        $this->quote->setBillingSameAsShipping(false);
+        $result = $mapper->mapQuoteToRequestTranfer($this->quote);
+        $this->assertInstanceOf(ArvatoRssDeliveryCustomerTransfer::class, $result->getDeliveryCustomer());
     }
 }

--- a/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Mapper/RiskCheckRequestMapperTest.php
+++ b/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Mapper/RiskCheckRequestMapperTest.php
@@ -55,7 +55,7 @@ class RiskCheckRequestMapperTest extends AbstractBusinessTest
         $this->assertInstanceOf(ArvatoRssIdentificationRequestTransfer::class, $result->getIdentification());
         $this->assertInstanceOf(ArvatoRssBillingCustomerTransfer::class, $result->getBillingCustomer());
         $this->assertInstanceOf(ArvatoRssOrderTransfer::class, $result->getOrder());
-        $this->assertNotEquals($quote->getBillingSameAsShipping(), (bool) $result->getDeliveryCustomer());
+        $this->assertNotEquals($quote->getBillingSameAsShipping(), $result->getDeliveryCustomer() !== null);
     }
 
     /**

--- a/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Mapper/RiskCheckRequestMapperTest.php
+++ b/tests/SprykerEcoTest/Zed/ArvatoRss/Business/Api/Mapper/RiskCheckRequestMapperTest.php
@@ -23,13 +23,13 @@ use SprykerEcoTest\Zed\ArvatoRss\Business\AbstractBusinessTest;
 class RiskCheckRequestMapperTest extends AbstractBusinessTest
 {
     /**
-     * @param QuoteTransfer $quote
+     * @param bool $billingSameAsShipping
      *
      * @dataProvider provideQuoteData
      *
      * @return void
      */
-    public function testMapQuoteToRequestTranfer(QuoteTransfer $quote)
+    public function testMapQuoteToRequestTranfer($billingSameAsShipping)
     {
         $mapper = new RiskCheckRequestMapper(
             $this->createIdentificationMapperMock(),
@@ -37,6 +37,8 @@ class RiskCheckRequestMapperTest extends AbstractBusinessTest
             $this->createDeliveryCustomerMapperMock(),
             $this->createOrderMapperMock()
         );
+        $quote = $this->quote;
+        $quote->setBillingSameAsShipping($billingSameAsShipping);
         $result = $mapper->mapQuoteToRequestTranfer($quote);
         $this->testResult($quote, $result);
     }
@@ -122,11 +124,9 @@ class RiskCheckRequestMapperTest extends AbstractBusinessTest
      */
     public static function provideQuoteData()
     {
-        $quoteBillingNotEqualDelivery = (new self())->quote;
-        $quoteBillingEqualDelivery = $quoteBillingNotEqualDelivery->setBillingSameAsShipping(true);
         return [
-            'quote: billing not equal delivery' => [$quoteBillingNotEqualDelivery],
-            'quote: billing equal delivery' => [$quoteBillingEqualDelivery],
+            'quote: billing not equal delivery' => [false],
+            'quote: billing equal delivery' => [true],
         ];
     }
 }


### PR DESCRIPTION
- Developer(s): @aleksey-kotsuba

- Peer Reviewer:

- Ticket: https://spryker.atlassian.net/browse/ECO-1044

- Project PR: https://github.com/spryker-eco/arvato-rss

- Academy PR:


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department
- [ ] All new or heavily changed classes get an "A" rating (Scrutinizer), except Facades, Factories, QueryContainers and Tests

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ArvatoRss             | patch (new)           |                       |

#### Release Notes



-----------------------------------------

#### Module ArvatoRss

_**Patch:** Backwards-compatible bug fix_

Def of done (by responsible developer):
- [ ] All changes are backward-compatible. Outdated code is marked as deprecated.
- [ ] The change is isolated and not mixed with any cleanups or other changes.
- [ ] New code fits to the architecture rules.
- [ ] All new or changed business logic is covered by functional tests (in Zed business layer).

##### Change log

### Bugfixes
Check for equal billing and shipping address has been added.
Only Billing address send if it's equal to shipping.

